### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     version='0.2',
     description='Text summarization (sentence extraction) module. (currently, support Japanese only)',
     long_description=long_description,
-    packages=['summpy'],
+    packages=['summpy', 'summpy.misc'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
The following code has an error without this change.

``` sh
$ cd summpy
$ pip install
$ cd ..
$ python
>>> from summpy.lexrank import summarize
```
